### PR TITLE
[WIP] Allow vl extensions for swmm views

### DIFF
--- a/swmm_views/02_vw_swmm_junctions.sql
+++ b/swmm_views/02_vw_swmm_junctions.sql
@@ -29,8 +29,9 @@ LEFT JOIN qgep_od.wastewater_networkelement we ON we.fk_wastewater_structure::te
 LEFT JOIN qgep_od.wastewater_node wn on wn.obj_id = we.obj_id
 LEFT JOIN qgep_od.cover co on ws.fk_main_cover = co.obj_id
 LEFT JOIN qgep_vl.manhole_function mf on ma.function = mf.code
+LEFT JOIN qgep_vl.wastewater_structure_status ws_st on ws_st.code=ws.status
 WHERE wn.obj_id IS NOT NULL
-AND status IN (6530, 6533, 8493, 6529, 6526, 7959)
+AND ws_st.vsacode IN (6530, 6533, 8493, 6529, 6526, 7959)
 
 UNION
 
@@ -59,10 +60,11 @@ LEFT JOIN qgep_od.wastewater_structure ws ON ws.obj_id::text = ss.obj_id::text
 LEFT JOIN qgep_od.wastewater_networkelement we ON we.fk_wastewater_structure::text = ws.obj_id::text
 LEFT JOIN qgep_od.wastewater_node wn on wn.obj_id = we.obj_id
 LEFT JOIN qgep_od.cover co on ws.fk_main_cover = co.obj_id
-LEFT JOIN qgep_vl.special_structure_function ssf on ss.function = ssf.code
+LEFT JOIN qgep_vl.special_structure_function ss_fu on ss_fu.code=ss.function
+LEFT JOIN qgep_vl.wastewater_structure_status ws_st on ws_st.code=ws.status
 WHERE wn.obj_id IS NOT NULL
-AND status IN (6530, 6533, 8493, 6529, 6526, 7959)
-AND function NOT IN ( -- must be the same list in vw_swmm_storages
+AND ws_st.vsacode IN (6530, 6533, 8493, 6529, 6526, 7959)
+AND ss_fu.vsacode NOT IN ( -- must be the same list in vw_swmm_storages
 6397, --"pit_without_drain"
 -- 245, --"drop_structure"
 6398, --"hydrolizing_tank"
@@ -126,8 +128,9 @@ LEFT JOIN qgep_od.channel ch on ch.obj_id::text = ws.obj_id::text
 -- Get wastewater structure linked to the from node
 LEFT JOIN qgep_od.wastewater_networkelement we ON from_wn.obj_id = we.obj_id
 LEFT JOIN qgep_od.wastewater_structure ws_node ON we.fk_wastewater_structure::text = ws_node.obj_id::text
+LEFT JOIN qgep_vl.wastewater_structure_status ws_st on ws_st.code=ws.status
 -- select only operationals and "planned"
-WHERE ws.status IN (6530, 6533, 8493, 6529, 6526, 7959)
+WHERE ws_st.vsacode IN (6530, 6533, 8493, 6529, 6526, 7959)
 and ws_node is null
 
 UNION
@@ -160,6 +163,7 @@ LEFT JOIN qgep_od.channel ch on ch.obj_id::text = ws.obj_id::text
 -- Get wastewater structure linked to the to node
 LEFT JOIN qgep_od.wastewater_networkelement we ON to_wn.obj_id = we.obj_id
 LEFT JOIN qgep_od.wastewater_structure ws_node ON we.fk_wastewater_structure::text = ws_node.obj_id::text
+LEFT JOIN qgep_vl.wastewater_structure_status ws_st on ws_st.code=ws.status
 -- select only operationals and "planned"
-WHERE ws.status IN (6530, 6533, 8493, 6529, 6526, 7959)
+WHERE ws_st.vsacode IN (6530, 6533, 8493, 6529, 6526, 7959)
 and ws_node is null;


### PR DESCRIPTION
For those who service data models other than VSA, value list extensions might be needed (i.e. AG-96 in the Canton of Aargau, which adds additional function_hierarchic for channels and drainage_system_* for catchment areas ). If one uses such extensions, the SWMM views won't work, as the hard-coded where clauses of the views have a different scope of options. By using the vsacode instead of the code in qgep_vl.*, these problems can be solved elegantly.

The pull request handles only the view qgep_swmm.vw_junctions so far. If the conceptual change is approved by @tproduit, I will extend oh the pull request.