### PR TITLE
Add label config for rp

### DIFF
--- a/05_data_model_extensions.sql
+++ b/05_data_model_extensions.sql
@@ -55,12 +55,12 @@ UPDATE qgep_vl.channel_function_hierarchic SET order_fct_hierarchic=14 WHERE cod
 
 -- this column is an extension to the VSA data model and defines whether connected channels are included in inflow/outflow labeling based on function_hierarchic
 ALTER TABLE qgep_vl.channel_function_hierarchic ADD COLUMN include_in_ws_labels boolean DEFAULT FALSE;
-UPDATE qgep_vl.channel_function_hierarchic SET order_fct_hierarchic=TRUE WHERE code=ANY('{5062,5064,5066,5068,5069,5070,5071,5072,5074}');
+UPDATE qgep_vl.channel_function_hierarchic SET include_in_ws_labels=TRUE WHERE code=ANY('{5062,5064,5066,5068,5069,5070,5071,5072,5074}');
 
 
 -- this column is an extension to the VSA data model and defines whether connected channels are included in inflow/outflow labeling based on function_hierarchic
 ALTER TABLE qgep_vl.wastewater_structure_status ADD COLUMN include_in_ws_labels boolean DEFAULT FALSE;
-UPDATE qgep_vl.wastewater_structure_status SET order_fct_hierarchic=TRUE WHERE code=ANY('{8493,6530,6533}');
+UPDATE qgep_vl.wastewater_structure_status SET include_in_ws_labels=TRUE WHERE code=ANY('{8493,6530,6533}');
 
 -- this column is an extension to the VSA data model and puts the _usage_current in order
 ALTER TABLE qgep_vl.channel_usage_current ADD COLUMN order_usage_current smallint;

--- a/05_data_model_extensions.sql
+++ b/05_data_model_extensions.sql
@@ -53,6 +53,15 @@ UPDATE qgep_vl.channel_function_hierarchic SET order_fct_hierarchic=12 WHERE cod
 UPDATE qgep_vl.channel_function_hierarchic SET order_fct_hierarchic=11 WHERE code=5074;
 UPDATE qgep_vl.channel_function_hierarchic SET order_fct_hierarchic=14 WHERE code=5075;
 
+-- this column is an extension to the VSA data model and defines whether connected channels are included in inflow/outflow labeling based on function_hierarchic
+ALTER TABLE qgep_vl.channel_function_hierarchic ADD COLUMN include_in_ws_labels boolean DEFAULT FALSE;
+UPDATE qgep_vl.channel_function_hierarchic SET order_fct_hierarchic=TRUE WHERE code=ANY('{5062,5064,5066,5068,5069,5070,5071,5072,5074}');
+
+
+-- this column is an extension to the VSA data model and defines whether connected channels are included in inflow/outflow labeling based on function_hierarchic
+ALTER TABLE qgep_vl.wastewater_structure_status ADD COLUMN include_in_ws_labels boolean DEFAULT FALSE;
+UPDATE qgep_vl.wastewater_structure_status SET order_fct_hierarchic=TRUE WHERE code=ANY('{8493,6530,6533}');
+
 -- this column is an extension to the VSA data model and puts the _usage_current in order
 ALTER TABLE qgep_vl.channel_usage_current ADD COLUMN order_usage_current smallint;
 UPDATE qgep_vl.channel_usage_current SET order_usage_current=5 WHERE code = 4514;

--- a/06_symbology_functions.sql
+++ b/06_symbology_functions.sql
@@ -459,13 +459,13 @@ LANGUAGE plpgsql VOLATILE;
 ------------
 
 CREATE OR REPLACE FUNCTION qgep_od.update_reach_point_label(_obj_id text, 
-	_all boolean default false,
-	_labeled_ws_status bigint[] DEFAULT '{8493,6530,6533}',
-	_labeled_ch_func_hier bigint[] DEFAULT '{5062,5064,5066,5068,5069,5070,5071,5072,5074}')
+	_all boolean default false
+	)
   RETURNS VOID AS
  $BODY$
   DECLARE
-  myrec record;
+  _labeled_ws_status bigint[] ;
+  _labeled_ch_func_hier bigint[]; 
   BEGIN
   -- Updates the reach_point labels of the wastewater_structure 
   -- _obj_id: obj_id of the associatied wastewater structure
@@ -473,6 +473,15 @@ CREATE OR REPLACE FUNCTION qgep_od.update_reach_point_label(_obj_id text,
   -- _labeled_ws_status: codes of the ws_status to be labeled. Default: Array of operational.xxx
   -- _labeled_ch_func_hier: codes of the ch_function_hierarchic to be labeled. Default: Array of pwwf.xxx
 
+-- check value lists for label inclusion
+SELECT array_agg(code) INTO _labeled_ws_status
+FROM qgep_vl.wastewater_structure_status
+WHERE include_in_ws_labels;
+	  
+SELECT array_agg(code) INTO _labeled_ch_func_hier
+FROM qgep_vl.channel_function_hierarchic
+WHERE include_in_ws_labels; 
+	  
 -- to prevent a re-throw of on_reach_point_update
   IF _all THEN
     RAISE INFO 'Temporarily disabling symbology triggers';


### PR DESCRIPTION
Includes a boolean column `include_in_ws_labels` for `qgep_vl.channel_function_hierarchic` and `qgep_vl.wastewater_structure_status`. This controls the `_labeled_ch_func_hier` and `_labeled_ws_status`, which are no longer function inputs but variables.