### PR TITLE
Save labels separately

### DIFF
--- a/05_data_model_extensions.sql
+++ b/05_data_model_extensions.sql
@@ -17,24 +17,6 @@ has to be updated by triggers';
 ALTER TABLE qgep_od.manhole ADD COLUMN _orientation numeric;
 COMMENT ON COLUMN qgep_od.manhole._orientation IS 'not part of the VSA-DSS data model
 added solely for TEKSI wastewater';
-ALTER TABLE qgep_od.wastewater_structure ADD COLUMN _label text;
-COMMENT ON COLUMN qgep_od.wastewater_structure._label IS 'not part of the VSA-DSS data model
-added solely for TEKSI wastewater';
-ALTER TABLE qgep_od.wastewater_structure ADD COLUMN _cover_label text;
-COMMENT ON COLUMN qgep_od.wastewater_structure._cover_label IS 'stores the cover altitude to be used for labelling, not part of the VSA-DSS data model
-added solely for TEKSI wastewater';
-ALTER TABLE qgep_od.wastewater_structure ADD COLUMN _input_label text;
-COMMENT ON COLUMN qgep_od.wastewater_structure._input_label IS 'stores the list of input altitudes to be used for labelling, not part of the VSA-DSS data model
-added solely for TEKSI wastewater';
-ALTER TABLE qgep_od.wastewater_structure ADD COLUMN _output_label text;
-COMMENT ON COLUMN qgep_od.wastewater_structure._output_label IS 'stores the list of output altitudes to be used for labelling, not part of the VSA-DSS data model
-added solely for TEKSI wastewater';
-ALTER TABLE qgep_od.wastewater_structure ADD COLUMN _bottom_label text;
-COMMENT ON COLUMN qgep_od.wastewater_structure._bottom_label IS 'stores the bottom altitude to be used for labelling, not part of the VSA-DSS data model
-added solely for TEKSI wastewater';
-ALTER TABLE qgep_od.reach_point ADD COLUMN _label text;
-COMMENT ON COLUMN qgep_od.reach_point._label IS 'not part of the VSA-DSS data model
-added solely for TEKSI wastewater';
 
 -- this column is an extension to the VSA data model and puts the _function_hierarchic in order
 ALTER TABLE qgep_vl.channel_function_hierarchic ADD COLUMN order_fct_hierarchic smallint;

--- a/05_data_model_extensions.sql
+++ b/05_data_model_extensions.sql
@@ -94,6 +94,21 @@ COMMENT ON COLUMN qgep_od.wastewater_node._status IS 'not part of the VSA-DSS da
 added solely for TEKSI wastewater
 has to be updated by triggers';
 
+-- label extensions
+CREATE TABLE IF NOT EXISTS qgep_od.labels
+(
+obj_id character varying(16) COLLATE pg_catalog."default" NOT NULL,
+    _label text COLLATE pg_catalog."default",
+    _cover_label text COLLATE pg_catalog."default",
+    _input_label text COLLATE pg_catalog."default",
+    _output_label text COLLATE pg_catalog."default",
+    _bottom_label text COLLATE pg_catalog."default",
+	CONSTRAINT pkey_qgep_od_labels_obj_id PRIMARY KEY (obj_id)
+)
+
+COMMENT ON COLUMN qgep_od.labels IS 'stores all labels. not part of the VSA-DSS data model
+added solely for TEKSI wastewater
+has to be updated by triggers';
 
 -- Modifications applied for link with SWMM
 -------------------------------------------

--- a/06_symbology_functions.sql
+++ b/06_symbology_functions.sql
@@ -326,15 +326,11 @@ CREATE OR REPLACE FUNCTION qgep_od.update_wastewater_structure_label(_obj_id tex
   BEGIN
   
   --Update wastewater structure label
-  -- 2023_05_12: use reach point labels
-  UPDATE qgep_od.wastewater_structure ws
-SET _label = label,
-    _cover_label = cover_label,
-    _bottom_label = bottom_label,
-    _input_label = input_label,
-    _output_label = output_label
-    FROM(
-SELECT   ws_obj_id,
+  -- 2023_10_10: use labels table
+ with labeled_ws as
+(
+	
+    SELECT   ws_obj_id as obj_id,
           COALESCE(ws_identifier, '') as label,
           CASE WHEN count(co_level)<2 THEN array_to_string(array_agg(E'\nC' || '=' || co_level ORDER BY idx DESC), '', '') ELSE
 		  array_to_string(array_agg(E'\nC' || idx || '=' || co_level ORDER BY idx ASC), '', '') END as cover_label,
@@ -393,10 +389,11 @@ SELECT   ws_obj_id,
 		, NULL::text AS bottom_level
 		, coalesce(round(RP.level, 2)::text, '?') AS rpi_level
 		, NULL::text AS rpo_level
-		, rp._label as rpi_label
+		, lb._label as rpi_label
 		,  NULL::text AS rpo_label
       FROM qgep_od.reach_point RP
       LEFT JOIN qgep_od.wastewater_networkelement NE ON RP.fk_wastewater_networkelement = NE.obj_id
+	  LEFT JOIN qgep_od.labels lb on RP.obj_id=lb.obj_id
       WHERE (_all OR NE.fk_wastewater_structure = _obj_id) and left(RP._label,1)='I'
       -- output
       UNION
@@ -408,17 +405,27 @@ SELECT   ws_obj_id,
 		, NULL::text AS rpi_level
 		, coalesce(round(RP.level, 2)::text, '?') AS rpo_level
 		, NULL::text as rpi_label
-		, rp._label AS rpo_label
+		, lb._label AS rpo_label
       FROM qgep_od.reach_point RP
       LEFT JOIN qgep_od.wastewater_networkelement NE ON RP.fk_wastewater_networkelement = NE.obj_id
-      WHERE (_all OR NE.fk_wastewater_structure = _obj_id) and left(RP._label,1)='O'
-	) AS parts ON parts.ws = ws.obj_id
+      LEFT JOIN qgep_od.labels lb on RP.obj_id=lb.obj_id
+	  WHERE (_all OR NE.fk_wastewater_structure = _obj_id) and left(RP._label,1)='O' 
+	) parts ON parts.ws = ws.obj_id
     WHERE _all OR ws.obj_id =_obj_id
-		  ) parts
-		  GROUP BY ws_obj_id, COALESCE(ws_identifier, '')
-) labeled_ws
-WHERE ws.obj_id = labeled_ws.ws_obj_id;
-
+    ) all_parts
+	GROUP BY ws_obj_id, COALESCE(ws_identifier, '')
+)
+  
+INSERT INTO qgep_od.labels (obj_id,_label,_cover_label,_bottom_label,_input_label,_output_label) 
+  SELECT  obj_id,label,cover_label,bottom_label,input_label,output_label
+  FROM labeled_ws
+  ON CONFLICT (obj_id) DO UPDATE
+SET _label = EXCLUDED._label,
+    _cover_label = EXCLUDED._cover_label,
+    _bottom_label = EXCLUDED._bottom_label,
+    _input_label = EXCLUDED._input_label,
+    _output_label = EXCLUDED._output_label
+;
 END
 
 $BODY$
@@ -485,18 +492,10 @@ WHERE include_in_ws_labels;
 SELECT array_agg(code) INTO _labeled_ch_func_hier
 FROM qgep_vl.channel_function_hierarchic
 WHERE include_in_ws_labels; 
-	  
--- to prevent a re-throw of on_reach_point_update
-  IF _all THEN
-    RAISE INFO 'Temporarily disabling symbology triggers';
-    PERFORM qgep_sys.drop_symbology_triggers();
-  END IF;
-  
- --Update reach_point label for those who should be labeled
-  UPDATE qgep_od.reach_point rp
-  SET _label = rp_label.new_label
-  FROM (
-  with  outp as( SELECT
+	
+    with  
+	--outputs
+	outp as( SELECT
     ne.fk_wastewater_structure
     , rp.obj_id
 	, ST_Azimuth(rp.situation_geometry,ST_PointN(re.progression_geometry,2)) as azimuth			
@@ -516,7 +515,9 @@ WHERE include_in_ws_labels;
 			AND ws.status = ANY(_labeled_ws_status) 
 		    AND ((_all AND ne.fk_wastewater_structure IS NOT NULL) 
 			  OR ne.fk_wastewater_structure= _obj_id)) ,
-	  inp as( SELECT
+	
+	--inputs
+	inp as( SELECT
     ne.fk_wastewater_structure
     , rp.obj_id
     , row_number() OVER(PARTITION BY NE.fk_wastewater_structure 
@@ -539,22 +540,10 @@ WHERE include_in_ws_labels;
 	  WHERE ch.function_hierarchic= ANY(_labeled_ch_func_hier) 
 			AND ws.status = ANY(_labeled_ws_status) 
 		    AND ((_all AND ne.fk_wastewater_structure IS NOT NULL) 
-			  OR ne.fk_wastewater_structure= _obj_id))
- 
-  SELECT 'I'||CASE WHEN max_idx=1 THEN '' ELSE idx::text END as new_label
-  , obj_id
-  FROM inp
- 
-  UNION
-  SELECT 'O'||CASE WHEN max_idx=1 THEN '' ELSE idx::text END as new_label
-  , obj_id
-  FROM outp) rp_label
-  WHERE rp_label.obj_id=rp.obj_id;
+			  OR ne.fk_wastewater_structure= _obj_id)),	
   
-  -- Set reach_point _label to NULL for those who should not be labeled
-  UPDATE qgep_od.reach_point rp
-  SET _label = NULL
-  FROM (
+  -- non-labeled rp
+  null_label as(
      SELECT
     ne.fk_wastewater_structure
     , rp.obj_id		
@@ -567,14 +556,29 @@ WHERE include_in_ws_labels;
 	  WHERE NOT(ch.function_hierarchic = ANY(_labeled_ch_func_hier) 
 			AND ws.status = ANY(_labeled_ws_status))
 		    AND ((_all AND ne.fk_wastewater_structure IS NOT NULL) 
-			  OR ne.fk_wastewater_structure= _obj_id)) null_label
-  WHERE null_label.obj_id=rp.obj_id;
-
-  -- See above
-  IF _all THEN
-    RAISE INFO 'Reenabling symbology triggers';
-    PERFORM qgep_sys.create_symbology_triggers();
-  END IF;
+			  OR ne.fk_wastewater_structure= _obj_id)),
+  
+  -- actual labels  
+  rp_label as 
+  (
+  SELECT 'I'||CASE WHEN max_idx=1 THEN '' ELSE idx::text END as new_label
+  , obj_id
+  FROM inp
+  UNION
+  SELECT 'O'||CASE WHEN max_idx=1 THEN '' ELSE idx::text END as new_label
+  , obj_id
+  FROM outp 
+  UNION
+  SELECT NULL as new_label
+  , obj_id
+  FROM null_label)
+ --Upsert reach_point labels 
+  INSERT INTO qgep_od.labels (obj_id,_label) 
+  SELECT  rp_label.obj_id,rp_label.new_label
+  FROM rp_label
+  ON CONFLICT (obj_id) DO 
+  UPDATE SET _label = EXCLUDED._label ;
+  
 END;
 $BODY$
 LANGUAGE plpgsql

--- a/delta/delta_1.6.1_update_rp_label.sql
+++ b/delta/delta_1.6.1_update_rp_label.sql
@@ -16,7 +16,6 @@ ALTER TABLE qgep_od.wastewater_structure DROP COLUMN IF EXISTS _cover_label ;
 ALTER TABLE qgep_od.wastewater_structure DROP COLUMN IF EXISTS _input_label ;
 ALTER TABLE qgep_od.wastewater_structure DROP COLUMN IF EXISTS _output_label ;
 ALTER TABLE qgep_od.wastewater_structure DROP COLUMN IF EXISTS _bottom_label ;
-ALTER TABLE qgep_od.rach_point DROP COLUMN IF EXISTS _label; --for cleanup of dev environment
 
 -- TABLE wastewater_node
 

--- a/delta/delta_1.6.1_update_rp_label.sql
+++ b/delta/delta_1.6.1_update_rp_label.sql
@@ -9,23 +9,14 @@ has to be updated by triggers';
 COMMENT ON COLUMN qgep_od.manhole._orientation IS 'not part of the VSA-DSS data model
 added solely for TEKSI wastewater';
 
-COMMENT ON COLUMN qgep_od.wastewater_structure._label IS 'not part of the VSA-DSS data model
-added solely for TEKSI wastewater';
 
-COMMENT ON COLUMN qgep_od.wastewater_structure._cover_label IS 'stores the cover altitude to be used for labelling, not part of the VSA-DSS data model
-added solely for TEKSI wastewater';
-
-COMMENT ON COLUMN qgep_od.wastewater_structure._input_label IS 'stores the list of input altitudes to be used for labelling, not part of the VSA-DSS data model
-added solely for TEKSI wastewater';
-
-COMMENT ON COLUMN qgep_od.wastewater_structure._output_label IS 'stores the list of output altitudes to be used for labelling, not part of the VSA-DSS data model
-added solely for TEKSI wastewater';
-
-COMMENT ON COLUMN qgep_od.wastewater_structure._bottom_label IS 'stores the bottom altitude to be used for labelling, not part of the VSA-DSS data model
-added solely for TEKSI wastewater';
-ALTER TABLE qgep_od.reach_point ADD COLUMN _label text;
-COMMENT ON COLUMN qgep_od.reach_point._label IS 'not part of the VSA-DSS data model
-added solely for TEKSI wastewater';
+--drop unnecessary labels
+ALTER TABLE qgep_od.wastewater_structure DROP COLUMN IF EXISTS _label ;
+ALTER TABLE qgep_od.wastewater_structure DROP COLUMN IF EXISTS _cover_label ;
+ALTER TABLE qgep_od.wastewater_structure DROP COLUMN IF EXISTS _input_label ;
+ALTER TABLE qgep_od.wastewater_structure DROP COLUMN IF EXISTS _output_label ;
+ALTER TABLE qgep_od.wastewater_structure DROP COLUMN IF EXISTS _bottom_label ;
+ALTER TABLE qgep_od.rach_point DROP COLUMN IF EXISTS _label; --for cleanup of dev environment
 
 -- TABLE wastewater_node
 

--- a/delta/delta_1.6.1_update_rp_label.sql
+++ b/delta/delta_1.6.1_update_rp_label.sql
@@ -81,18 +81,10 @@ WHERE include_in_ws_labels;
 SELECT array_agg(code) INTO _labeled_ch_func_hier
 FROM qgep_vl.channel_function_hierarchic
 WHERE include_in_ws_labels; 
-	  
--- to prevent a re-throw of on_reach_point_update
-  IF _all THEN
-    RAISE INFO 'Temporarily disabling symbology triggers';
-    PERFORM qgep_sys.drop_symbology_triggers();
-  END IF;
-  
- --Update reach_point label for those who should be labeled
-  UPDATE qgep_od.reach_point rp
-  SET _label = rp_label.new_label
-  FROM (
-  with  outp as( SELECT
+	
+    with  
+	--outputs
+	outp as( SELECT
     ne.fk_wastewater_structure
     , rp.obj_id
 	, ST_Azimuth(rp.situation_geometry,ST_PointN(re.progression_geometry,2)) as azimuth			
@@ -112,7 +104,9 @@ WHERE include_in_ws_labels;
 			AND ws.status = ANY(_labeled_ws_status) 
 		    AND ((_all AND ne.fk_wastewater_structure IS NOT NULL) 
 			  OR ne.fk_wastewater_structure= _obj_id)) ,
-	  inp as( SELECT
+	
+	--inputs
+	inp as( SELECT
     ne.fk_wastewater_structure
     , rp.obj_id
     , row_number() OVER(PARTITION BY NE.fk_wastewater_structure 
@@ -135,22 +129,10 @@ WHERE include_in_ws_labels;
 	  WHERE ch.function_hierarchic= ANY(_labeled_ch_func_hier) 
 			AND ws.status = ANY(_labeled_ws_status) 
 		    AND ((_all AND ne.fk_wastewater_structure IS NOT NULL) 
-			  OR ne.fk_wastewater_structure= _obj_id))
- 
-  SELECT 'I'||CASE WHEN max_idx=1 THEN '' ELSE idx::text END as new_label
-  , obj_id
-  FROM inp
- 
-  UNION
-  SELECT 'O'||CASE WHEN max_idx=1 THEN '' ELSE idx::text END as new_label
-  , obj_id
-  FROM outp) rp_label
-  WHERE rp_label.obj_id=rp.obj_id;
+			  OR ne.fk_wastewater_structure= _obj_id)),	
   
-  -- Set reach_point _label to NULL for those who should not be labeled
-  UPDATE qgep_od.reach_point rp
-  SET _label = NULL
-  FROM (
+  -- non-labeled rp
+  null_label as(
      SELECT
     ne.fk_wastewater_structure
     , rp.obj_id		
@@ -163,14 +145,29 @@ WHERE include_in_ws_labels;
 	  WHERE NOT(ch.function_hierarchic = ANY(_labeled_ch_func_hier) 
 			AND ws.status = ANY(_labeled_ws_status))
 		    AND ((_all AND ne.fk_wastewater_structure IS NOT NULL) 
-			  OR ne.fk_wastewater_structure= _obj_id)) null_label
-  WHERE null_label.obj_id=rp.obj_id;
-
-  -- See above
-  IF _all THEN
-    RAISE INFO 'Reenabling symbology triggers';
-    PERFORM qgep_sys.create_symbology_triggers();
-  END IF;
+			  OR ne.fk_wastewater_structure= _obj_id)),
+  
+  -- actual labels  
+  rp_label as 
+  (
+  SELECT 'I'||CASE WHEN max_idx=1 THEN '' ELSE idx::text END as new_label
+  , obj_id
+  FROM inp
+  UNION
+  SELECT 'O'||CASE WHEN max_idx=1 THEN '' ELSE idx::text END as new_label
+  , obj_id
+  FROM outp 
+  UNION
+  SELECT NULL as new_label
+  , obj_id
+  FROM null_label)
+ --Upsert reach_point labels 
+  INSERT INTO qgep_od.labels (obj_id,_label) 
+  SELECT  rp_label.obj_id,rp_label.new_label
+  FROM rp_label
+  ON CONFLICT (obj_id) DO 
+  UPDATE SET _label = EXCLUDED._label ;
+  
 END;
 $BODY$
 LANGUAGE plpgsql
@@ -250,15 +247,11 @@ CREATE OR REPLACE FUNCTION qgep_od.update_wastewater_structure_label(_obj_id tex
   BEGIN
   
   --Update wastewater structure label
-  -- 2023_05_12: use reach point labels
-  UPDATE qgep_od.wastewater_structure ws
-SET _label = label,
-    _cover_label = cover_label,
-    _bottom_label = bottom_label,
-    _input_label = input_label,
-    _output_label = output_label
-    FROM(
-SELECT   ws_obj_id,
+  -- 2023_10_10: use labels table
+ with labeled_ws as
+(
+	
+    SELECT   ws_obj_id as obj_id,
           COALESCE(ws_identifier, '') as label,
           CASE WHEN count(co_level)<2 THEN array_to_string(array_agg(E'\nC' || '=' || co_level ORDER BY idx DESC), '', '') ELSE
 		  array_to_string(array_agg(E'\nC' || idx || '=' || co_level ORDER BY idx ASC), '', '') END as cover_label,
@@ -317,10 +310,11 @@ SELECT   ws_obj_id,
 		, NULL::text AS bottom_level
 		, coalesce(round(RP.level, 2)::text, '?') AS rpi_level
 		, NULL::text AS rpo_level
-		, rp._label as rpi_label
+		, lb._label as rpi_label
 		,  NULL::text AS rpo_label
       FROM qgep_od.reach_point RP
       LEFT JOIN qgep_od.wastewater_networkelement NE ON RP.fk_wastewater_networkelement = NE.obj_id
+	  LEFT JOIN qgep_od.labels lb on RP.obj_id=lb.obj_id
       WHERE (_all OR NE.fk_wastewater_structure = _obj_id) and left(RP._label,1)='I'
       -- output
       UNION
@@ -332,17 +326,27 @@ SELECT   ws_obj_id,
 		, NULL::text AS rpi_level
 		, coalesce(round(RP.level, 2)::text, '?') AS rpo_level
 		, NULL::text as rpi_label
-		, rp._label AS rpo_label
+		, lb._label AS rpo_label
       FROM qgep_od.reach_point RP
       LEFT JOIN qgep_od.wastewater_networkelement NE ON RP.fk_wastewater_networkelement = NE.obj_id
-      WHERE (_all OR NE.fk_wastewater_structure = _obj_id) and left(RP._label,1)='O'
-	) AS parts ON parts.ws = ws.obj_id
+      LEFT JOIN qgep_od.labels lb on RP.obj_id=lb.obj_id
+	  WHERE (_all OR NE.fk_wastewater_structure = _obj_id) and left(RP._label,1)='O' 
+	) parts ON parts.ws = ws.obj_id
     WHERE _all OR ws.obj_id =_obj_id
-		  ) parts
-		  GROUP BY ws_obj_id, COALESCE(ws_identifier, '')
-) labeled_ws
-WHERE ws.obj_id = labeled_ws.ws_obj_id;
-
+    ) all_parts
+	GROUP BY ws_obj_id, COALESCE(ws_identifier, '')
+)
+  
+INSERT INTO qgep_od.labels (obj_id,_label,_cover_label,_bottom_label,_input_label,_output_label) 
+  SELECT  obj_id,label,cover_label,bottom_label,input_label,output_label
+  FROM labeled_ws
+  ON CONFLICT (obj_id) DO UPDATE
+SET _label = EXCLUDED._label,
+    _cover_label = EXCLUDED._cover_label,
+    _bottom_label = EXCLUDED._bottom_label,
+    _input_label = EXCLUDED._input_label,
+    _output_label = EXCLUDED._output_label
+;
 END
 
 $BODY$

--- a/view/vw_qgep_reach.py
+++ b/view/vw_qgep_reach.py
@@ -52,7 +52,9 @@ def vw_qgep_reach(pg_service: str = None,
         , {ch_cols}
         , {ws_cols}
         , {rp_from_cols}
+        , rp_from_label._label as rp_from_label 
         , {rp_to_cols}
+        , rp_to_label._label as rp_to_label
       FROM qgep_od.reach re
          LEFT JOIN qgep_od.wastewater_networkelement ne ON ne.obj_id = re.obj_id
          LEFT JOIN qgep_od.reach_point rp_from ON rp_from.obj_id = re.fk_reach_point_from
@@ -60,7 +62,9 @@ def vw_qgep_reach(pg_service: str = None,
          LEFT JOIN qgep_od.wastewater_structure ws ON ne.fk_wastewater_structure = ws.obj_id
          LEFT JOIN qgep_od.channel ch ON ch.obj_id = ws.obj_id
          LEFT JOIN qgep_od.pipe_profile pp ON re.fk_pipe_profile = pp.obj_id
-         {extra_joins};
+         {extra_joins}
+         LEFT JOIN qgep_od.labels rp_from_label ON rp_from_label.obj_id = rp_from.obj_id
+         LEFT JOIN qgep_od.labels rp_to_label ON rp_to_label.obj_id = rp_to.obj_id;
     """.format(extra_cols='\n    , '.join([select_columns(pg_cur=cursor,
                                                           table_schema=table_parts(table_def['table'])[0],
                                                           table_name=table_parts(table_def['table'])[1],

--- a/view/vw_qgep_wastewater_structure.py
+++ b/view/vw_qgep_wastewater_structure.py
@@ -70,11 +70,11 @@ def vw_qgep_wastewater_structure(srid: int,
         , {wn_cols}
         , {ne_cols}
 
-        , ws._label
-        , ws._cover_label
-        , ws._bottom_label
-        , ws._input_label
-        , ws._output_label
+        , labl._label
+        , labl._cover_label
+        , labl._bottom_label
+        , labl._input_label
+        , labl._output_label
         , ws._usage_current AS _channel_usage_current
         , ws._function_hierarchic AS _channel_function_hierarchic
 
@@ -88,6 +88,7 @@ def vw_qgep_wastewater_structure(srid: int,
         LEFT JOIN qgep_od.wastewater_networkelement ne ON ne.obj_id = ws.fk_main_wastewater_node
         LEFT JOIN qgep_od.wastewater_node wn ON wn.obj_id = ws.fk_main_wastewater_node
         LEFT JOIN qgep_od.channel ch ON ch.obj_id = ws.obj_id
+        LEFT JOIN qgep_od.labels labl ON labl.obj_id = ws.obj_id
         {extra_joins}
         WHERE ch.obj_id IS NULL;
 


### PR DESCRIPTION
In order to facilitate label management and not throwing cascading triggers on label updates, labels are now stored in a separate table